### PR TITLE
makefile: remove tabs

### DIFF
--- a/mode/makefile/makefile.js
+++ b/mode/makefile/makefile.js
@@ -53,7 +53,7 @@ CodeMirror.defineMode('makefile', function() {
       if ((stream.match(/^[\w]+[\s]+/) || stream.match(/^[\w]+/)) &&
          (stream.peek() === '=' ||
          ((stream.match('?') || stream.match('+') || stream.match('-')) && stream.peek() === '='))
-	     ) { return "variable-2"; }
+         ) { return "variable-2"; }
 
       // Makefile targets
       if ( stream.eat(':') || stream.match(/^[\w]+:/) || stream.match(/^(.)+[\w]+:/) ||
@@ -135,7 +135,7 @@ CodeMirror.defineMode('makefile', function() {
     token: function(stream, state) {
       return tokenize(stream, state);
     },
-	lineComment: "#"
+  lineComment: "#"
   };
 });
 


### PR DESCRIPTION
Not sure if actually worth a pull request, but CodeMirror's lint tool complained about it (CodeMirror coding style requires spaces instead of tabs).